### PR TITLE
resolve dolark dolo dependency disagreement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ numpy = "^1.19.1"
 tqdm = "^4.48.2"
 scipy = "^1.4.1"
 ipython = "^8.5.0"
-jupyterlab = "^2.2.6"
+jupyterlab = "^3.0.0"
 altair = "^4.1.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,13 @@ license = "BSD-2-Clause"
 
 [tool.poetry.dependencies]
 python = ">=3.7, <3.10"
-dolo =  { git = "https://github.com/EconForge/dolo.py" }
-dolang =  { git = "https://github.com/EconForge/dolang.py" }
+dolo =  { git = "https://github.com/EconForge/dolo.py@v0.4.9.18" }
+dolang =  { git = "https://github.com/EconForge/dolang.py@v0.0.18" }
 numpy = "^1.19.1"
 tqdm = "^4.48.2"
 scipy = "^1.4.1"
+ipython = "^8.5.0"
 jupyterlab = "^2.2.6"
-ipython = "^7.17.0"
 altair = "^4.1.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
`dolark` has an `ipython` version requirement that directly conflicts with `dolo`. 

This PR upgrades `dolark` ipython dependency to match that of `dolo`. 
Additionally, I've pinned the `dolo` and `dolang` dependencies to tagged versions, which will *help* prevent version slippage in the future.